### PR TITLE
Fix KOTH crashing on high framerate

### DIFF
--- a/entities/entities/koth_point/shared.lua
+++ b/entities/entities/koth_point/shared.lua
@@ -652,7 +652,7 @@ function ENT:OnRemove()
 	end
 end
 
-
+local draw_time = 0
 function ENT:Draw()
 
 	self:SetRenderBounds( vec_mins, vec_maxs )
@@ -662,7 +662,10 @@ function ENT:Draw()
 
 	-- for potential crash debugging
 	if !DD_SIMPLEKOTHRING then
-		self:RebuildMesh()
+		if draw_time < CurTime() then
+			draw_time = CurTime() + 0.01
+			self:RebuildMesh()
+		end
 		self:DrawMesh()
 	end
 


### PR DESCRIPTION
A fix for the King of the Hill game mode crashing when playing on high framerate by limiting point mesh rebuilding to every 10 milliseconds instead of every frame. 10 milliseconds should be fast enough for the mesh color change to be seen immediately.