### PR TITLE
Fix trying to call a nil method on entity in weapon base

### DIFF
--- a/entities/weapons/dd_base/shared.lua
+++ b/entities/weapons/dd_base/shared.lua
@@ -916,7 +916,7 @@ function GenericBulletCallback(attacker, tr, dmginfo)//function GenericBulletCal
 			end
 		else
 			local phys = ent:GetPhysicsObject()
-			if ent:GetMoveType() == MOVETYPE_VPHYSICS and phys:IsValid() and phys:IsMoveable() then
+			if IsValid(attacker) and ent.SetPhysicsAttacker and ent:GetMoveType() == MOVETYPE_VPHYSICS and phys:IsValid() and phys:IsMoveable() then
 				ent:SetPhysicsAttacker(attacker)
 			end
 		end


### PR DESCRIPTION
A fix for weapon base trying to call a function that does not exist on entity.